### PR TITLE
[REFACTOR] 채팅방, 채팅메시지 관련 기능 리펙토링

### DIFF
--- a/src/main/java/mediHub_be/chat/controller/ChatroomController.java
+++ b/src/main/java/mediHub_be/chat/controller/ChatroomController.java
@@ -76,7 +76,8 @@ public class ChatroomController {
     @Operation(summary = "채팅방 참여자 조회", description = "특정 채팅방 참여자 조회")
     @GetMapping("/{chatroomSeq}/user")
     public ResponseEntity<ApiResponse<List<ResponseChatUserDTO>>> getChatUsers(@PathVariable Long chatroomSeq) {
-        List<ResponseChatUserDTO> users = chatroomService.getChatUsers(chatroomSeq);
+        Long userSeq = SecurityUtil.getCurrentUserSeq();
+        List<ResponseChatUserDTO> users = chatroomService.getChatUsers(userSeq, chatroomSeq);
         return ResponseEntity.ok(ApiResponse.ok(users));
     }
 

--- a/src/main/java/mediHub_be/chat/dto/ResponseChatMessageDTO.java
+++ b/src/main/java/mediHub_be/chat/dto/ResponseChatMessageDTO.java
@@ -17,6 +17,7 @@ public class ResponseChatMessageDTO {
     private Long chatroomSeq;
     private Long senderUserSeq;
     private String senderUserName;
+    private String senderUserProfileUrl;
     private String type;
     private String message;
     private LocalDateTime createdAt;

--- a/src/main/java/mediHub_be/chat/dto/ResponseChatUserDTO.java
+++ b/src/main/java/mediHub_be/chat/dto/ResponseChatUserDTO.java
@@ -12,6 +12,7 @@ import lombok.NoArgsConstructor;
 public class ResponseChatUserDTO {
     private Long userSeq;
     private String userName;    // 직원 이름
+    private String userProfileUrl;  // 직원 프로필 사진
     private String partName;    // 과명
     private String rankingName; // 직급명
 }

--- a/src/main/java/mediHub_be/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/mediHub_be/chat/repository/ChatMessageRepository.java
@@ -4,13 +4,14 @@ import mediHub_be.chat.entity.ChatMessage;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Repository
 public interface ChatMessageRepository extends MongoRepository<ChatMessage, String> {
 
-    List<ChatMessage> findByChatroomSeqAndIsDeletedFalseOrderByCreatedAtAsc(Long chatroomSeq);
-
     ChatMessage findTopByChatroomSeqAndIsDeletedFalseOrderByCreatedAtDesc(Long chatroomSeq);
+
+    List<ChatMessage> findByChatroomSeqAndCreatedAtAfterAndIsDeletedFalseOrderByCreatedAtAsc(Long chatroomSeq, LocalDateTime userJoinDate);
 }
 

--- a/src/main/java/mediHub_be/chat/repository/ChatRepository.java
+++ b/src/main/java/mediHub_be/chat/repository/ChatRepository.java
@@ -2,8 +2,10 @@ package mediHub_be.chat.repository;
 
 import mediHub_be.chat.entity.Chat;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -17,5 +19,10 @@ public interface ChatRepository extends JpaRepository<Chat, Long> {
     List<Chat> findByChatroom_ChatroomSeq(Long chatroomSeq);
 
     List<Chat> findByUser_UserSeq(Long userSeq);
+
+    @Query("SELECT c.joinedAt FROM Chat c WHERE c.user.userSeq = :userSeq AND c.chatroom.chatroomSeq = :chatroomSeq")
+    LocalDateTime findJoinDateByUserSeqAndChatroomSeq(Long userSeq, Long chatroomSeq);
+
+    boolean existsByChatroomChatroomSeqAndUserUserSeq(Long chatroomSeq, Long userSeq);
 }
 

--- a/src/main/java/mediHub_be/chat/service/KafkaConsumerService.java
+++ b/src/main/java/mediHub_be/chat/service/KafkaConsumerService.java
@@ -1,7 +1,6 @@
 package mediHub_be.chat.service;
 
 import mediHub_be.chat.KafkaConstants;
-import mediHub_be.chat.dto.ChatMessageDTO;
 import mediHub_be.chat.dto.ResponseChatMessageDTO;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
@@ -17,21 +16,11 @@ public class KafkaConsumerService {
 
     // Kafka에서 메시지를 수신하고, STOMP 구독자에게 메시지 전송
     @KafkaListener(topics = KafkaConstants.KAFKA_TOPIC, containerFactory = "kafkaListenerContainerFactory")
-    public void consumeMessage(ChatMessageDTO message) {
+    public void consumeMessage(ResponseChatMessageDTO message) {
         String destination = "/subscribe/" + message.getChatroomSeq();  // 채팅방별 구독 경로
-        ResponseChatMessageDTO response = convertToResponseDTO(message);
 
         // 해당 채팅방을 구독하고 있는 사용자들에게 메시지 전송
-        messagingTemplate.convertAndSend(destination, response);
+        messagingTemplate.convertAndSend(destination, message);
     }
 
-    private ResponseChatMessageDTO convertToResponseDTO(ChatMessageDTO message) {
-        return ResponseChatMessageDTO.builder()
-                .chatroomSeq(message.getChatroomSeq())
-                .senderUserSeq(message.getSenderUserSeq())
-                .message(message.getMessage())
-                .createdAt(message.getCreatedAt())
-                .attachments(message.getAttachments())
-                .build();
-    }
 }

--- a/src/main/java/mediHub_be/chat/service/KafkaProducerService.java
+++ b/src/main/java/mediHub_be/chat/service/KafkaProducerService.java
@@ -1,18 +1,18 @@
 package mediHub_be.chat.service;
 
-import mediHub_be.chat.dto.ChatMessageDTO;
+import mediHub_be.chat.dto.ResponseChatMessageDTO;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
 
 @Service
 public class KafkaProducerService {
-    private final KafkaTemplate<String, ChatMessageDTO> kafkaTemplate;
+    private final KafkaTemplate<String, ResponseChatMessageDTO> kafkaTemplate;
 
-    public KafkaProducerService(KafkaTemplate<String, ChatMessageDTO> kafkaTemplate) {
+    public KafkaProducerService(KafkaTemplate<String, ResponseChatMessageDTO> kafkaTemplate) {
         this.kafkaTemplate = kafkaTemplate;
     }
 
-    public void sendMessageToKafka(ChatMessageDTO message) {
+    public void sendMessageToKafka(ResponseChatMessageDTO message) {
         String topic = "chat-topic";  // 채팅방별 토픽
         kafkaTemplate.send(topic, message);  // Kafka에 메시지 전송
     }

--- a/src/main/java/mediHub_be/common/exception/ErrorCode.java
+++ b/src/main/java/mediHub_be/common/exception/ErrorCode.java
@@ -110,6 +110,9 @@ public enum ErrorCode {
     DUPLICATE_CP_SEARCH_CATEGORY_NAME(40902, HttpStatus.CONFLICT, "이미 존재하는 CP 검색 카테고리 입니다."),
     DUPLICATE_CP_SEARCH_CATEGORY_DATA_NAME(40903, HttpStatus.CONFLICT, "이미 존재하는 CP 검색 카테고리 데이터 입니다."),
 
+    // 채팅방 관련 중복
+    USER_ALREADY_IN_CHATROOM(40904, HttpStatus.CONFLICT, "이미 채팅방에 있는 사용자입니다."),
+
     /**
      * == 500 INTERNAL_SERVER_ERROR ==
      */

--- a/src/main/java/mediHub_be/config/KafkaProducerConfig.java
+++ b/src/main/java/mediHub_be/config/KafkaProducerConfig.java
@@ -1,7 +1,7 @@
 package mediHub_be.config;
 
 import mediHub_be.chat.KafkaConstants;
-import mediHub_be.chat.dto.ChatMessageDTO;
+import mediHub_be.chat.dto.ResponseChatMessageDTO;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.springframework.context.annotation.Bean;
@@ -18,12 +18,12 @@ import java.util.Map;
 public class KafkaProducerConfig {
 
     @Bean
-    public KafkaTemplate<String, ChatMessageDTO> kafkaTemplate() {
+    public KafkaTemplate<String, ResponseChatMessageDTO> kafkaTemplate() {
         return new KafkaTemplate<>(producerFactory());
     }
 
     @Bean
-    public ProducerFactory<String, ChatMessageDTO> producerFactory() {
+    public ProducerFactory<String, ResponseChatMessageDTO> producerFactory() {
         Map<String, Object> configProps = new HashMap<>();
         configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, KafkaConstants.KAFKA_BROKER);
         configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);    // key(토픽 이름)


### PR DESCRIPTION
cloase: #165 
## 구현기능
- 특정 채팅방 내 메시지 목록 조회 시 사용자가 채팅방에 참여한 일시 이후로 조회되도록 수정
- 사용자가 참여하고 있는 채팅방이 아니라면 참여자 정보를 조회할 수 없도록 수정
- 채팅방에 대화상대 추가 시 이미 채팅방에 있는 참여자라면 예외 발생
- ResponseMessageDTO에 메시지 전송자 프로필 사진 필드 추가
- 메시지 발행, 수신 로직 수정(MongoDB에 저장 후 kafka로 전송)