### PR TITLE
[FEAT] 사진 저장 방식 수정 및 자잘한 오류 수정

### DIFF
--- a/src/main/java/mediHub_be/amazonS3/service/AmazonS3Service.java
+++ b/src/main/java/mediHub_be/amazonS3/service/AmazonS3Service.java
@@ -107,6 +107,43 @@ public class AmazonS3Service {
         return newFileName;
     }
 
+    public MetaData uploadFromByteArray(byte[] imageBytes, String fileName, String contentType) {
+
+        MetaData metaData = new MetaData();
+
+        // 파일 이름 변경
+        String changedFileName = changeFileName(fileName);
+
+        metaData.setOriginalFileName(fileName);
+        metaData.setChangeFileName(changedFileName);
+
+        // S3에 업로드할 파일의 메타 데이터 생성
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentType(contentType);
+        metadata.setContentLength(imageBytes.length);
+
+        try {
+            // S3에 파일 업로드
+            amazonS3Client.putObject(amazonS3Bucket, changedFileName, new java.io.ByteArrayInputStream(imageBytes), metadata);
+
+            // 업로드된 파일의 URL 생성
+            String fileUrl = amazonS3Client.getUrl(amazonS3Bucket, changedFileName).toString();
+            metaData.setUrl(fileUrl);
+            metaData.setType(contentType);
+
+            // 로그 출력
+            log.info("origin name = " + metaData.getOriginalFileName());
+            log.info("changed name = " + metaData.getChangeFileName());
+            log.info("url = " + metaData.getUrl());
+
+            return metaData;
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.INTERNAL_SERVER_IO_UPLOAD_ERROR);
+        }
+    }
+
+
+
     @Getter
     @Setter
     public static class MetaData {

--- a/src/main/java/mediHub_be/board/service/PictureService.java
+++ b/src/main/java/mediHub_be/board/service/PictureService.java
@@ -1,5 +1,8 @@
 package mediHub_be.board.service;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import mediHub_be.amazonS3.service.AmazonS3Service;
@@ -28,6 +31,71 @@ public class PictureService {
     private final PictureRepository pictureRepository;
     private final AmazonS3Service amazonS3Service;
     private final FlagService flagService;
+
+    @Transactional
+    public String replaceBase64WithUrls(String content, String flagType, Long entitySeq) {
+        try {
+            ObjectMapper objectMapper = new ObjectMapper();
+            JsonNode contentNode = objectMapper.readTree(content);
+
+            Flag flag = flagService.findFlag(flagType, entitySeq).orElse(null);
+
+            // Base64 이미지 처리
+            List<String> uploadedUrls = new ArrayList<>();
+            for (JsonNode block : contentNode.get("blocks")) {
+                if ("image".equals(block.get("type").asText())) {
+                    JsonNode fileNode = block.get("data").get("file");
+                    String base64Url = fileNode.get("url").asText();
+
+                    if (base64Url.startsWith("data:image")) {
+                        String uploadedUrl = uploadBase64Image(base64Url, flag);
+                        uploadedUrls.add(uploadedUrl);
+
+                        // JSON 노드 URL 교체
+                        ((ObjectNode) fileNode).put("url", uploadedUrl);
+                    }
+                }
+            }
+
+            // 트랜잭션 롤백 시 S3에서 삭제 처리
+            registerRollbackHandler(uploadedUrls);
+
+            return objectMapper.writeValueAsString(contentNode);
+        } catch (IOException e) {
+            throw new CustomException(ErrorCode.INTERNAL_SERVER_IO_UPLOAD_ERROR);
+        }
+    }
+
+    private String uploadBase64Image(String base64Data, Flag flag) {
+        try {
+            // Base64 데이터를 디코딩
+            String[] parts = base64Data.split(",");
+            String base64Image = parts[1];
+            String fileExtension = parts[0].split(";")[0].split("/")[1];
+
+            byte[] decodedBytes = java.util.Base64.getDecoder().decode(base64Image);
+            String fileName = "uploaded_image_" + System.currentTimeMillis() + "." + fileExtension;
+
+            // S3 업로드
+            AmazonS3Service.MetaData metaData = amazonS3Service.uploadFromByteArray(decodedBytes, fileName, fileExtension);
+
+            // Picture 엔티티 저장
+            Picture pic = Picture.builder()
+                    .flag(flag)
+                    .pictureName(fileName)
+                    .pictureChangedName(metaData.getChangeFileName())
+                    .pictureUrl(metaData.getUrl())
+                    .pictureType(fileExtension)
+                    .pictureIsDeleted(false)
+                    .build();
+            pictureRepository.save(pic);
+
+            return metaData.getUrl();
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.INTERNAL_SERVER_IO_UPLOAD_ERROR);
+        }
+    }
+
 
     // 이미지 업로드 및 Picture 엔터티 생성
     @Transactional
@@ -61,14 +129,24 @@ public class PictureService {
     public String replacePlaceHolderWithUrls(String content, List<MultipartFile> images, String flagType, Long entitySeq) {
         List<String> urls = uploadPictureWithFlag(flagType, entitySeq, images);
 
-        // 태그와 URL 매핑
-        for (int i = 0; i < urls.size(); i++) {
-            String placeholder = "[img-" + (i + 1) + "]"; // `[img-1]`, `[img-2]`, ...
-            content = content.replace(placeholder, "<img src='" + urls.get(i) + "' />");
-        }
+        try {
+            ObjectMapper objectMapper = new ObjectMapper();
+            JsonNode contentNode = objectMapper.readTree(content);
 
-        return content;
+            int imageIndex = 0;
+            for (JsonNode block : contentNode.get("blocks")) {
+                if ("image".equals(block.get("type").asText()) && imageIndex < urls.size()) {
+                    ((ObjectNode) block.get("data")).put("file", urls.get(imageIndex));
+                    imageIndex++;
+                }
+            }
+
+            return objectMapper.writeValueAsString(contentNode);
+        } catch (IOException e) {
+            throw new CustomException(ErrorCode.INTERNAL_SERVER_IO_UPLOAD_ERROR);
+        }
     }
+
 
     @Transactional
     public String uploadPicture(MultipartFile picture, Flag flag) {

--- a/src/main/java/mediHub_be/config/SecurityConfig.java
+++ b/src/main/java/mediHub_be/config/SecurityConfig.java
@@ -45,15 +45,16 @@ public class SecurityConfig {
         http.csrf(csrf -> csrf.disable())
                 .authorizeHttpRequests(authz -> authz
                                 .requestMatchers("/**").permitAll()
-                                .requestMatchers(new AntPathRequestMatcher("/api/v1/user/login", "POST")).permitAll() // 로그인 API 허용
-                                .requestMatchers(new AntPathRequestMatcher("/api/v1/token/reissue")).permitAll()
-                                .requestMatchers(new AntPathRequestMatcher("/swagger-resources/**")).permitAll()
-                                .requestMatchers(new AntPathRequestMatcher("/swagger-ui/**")).permitAll()
-                                .requestMatchers(new AntPathRequestMatcher("/v3/api-docs/**")).permitAll()
-                                .requestMatchers(new AntPathRequestMatcher("/webjars/**")).permitAll()
-                                .requestMatchers(new AntPathRequestMatcher("/case_sharing/**")).permitAll()
-                                .requestMatchers(new AntPathRequestMatcher("/cp/**")).permitAll()
-                                .anyRequest().authenticated() // 그 외 요청은 인증 필요
+                        .requestMatchers(new AntPathRequestMatcher("/api/v1/user/login", "POST")).permitAll() // 로그인 API 허용
+//                        .requestMatchers(new AntPathRequestMatcher("/api/**")).permitAll() // 로그인 API 허용
+                        .requestMatchers(new AntPathRequestMatcher("/api/v1/token/reissue")).permitAll()
+                        .requestMatchers(new AntPathRequestMatcher("/swagger-resources/**")).permitAll()
+                        .requestMatchers(new AntPathRequestMatcher("/swagger-ui/**")).permitAll()
+                        .requestMatchers(new AntPathRequestMatcher("/v3/api-docs/**")).permitAll()
+                        .requestMatchers(new AntPathRequestMatcher("/webjars/**")).permitAll()
+                       .requestMatchers(new AntPathRequestMatcher("/case_sharing/**")).permitAll()
+
+                        .anyRequest().authenticated() // 그 외 요청은 인증 필요
                 )
                 /* 세션 정책 설정 (Stateless) */
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
@@ -101,7 +102,6 @@ public class SecurityConfig {
         config.addAllowedMethod("*"); // 모든 HTTP 메소드 허용
         config.addExposedHeader("token"); // 서버에서 클라이언트로 반환하는 헤더 허용
         config.addExposedHeader("Authorization");
-
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", config);
         return source;

--- a/src/main/java/mediHub_be/dept/entity/Dept.java
+++ b/src/main/java/mediHub_be/dept/entity/Dept.java
@@ -13,7 +13,6 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Entity
 @Table(name = "dept")
 @EntityListeners(AuditingEntityListener.class)
-@SQLDelete(sql = "UPDATE dept SET del_date = LOCALTIME WHERE dept_seq = ?")
 public class Dept {
 
     @Id

--- a/src/main/java/mediHub_be/part/controller/PartController.java
+++ b/src/main/java/mediHub_be/part/controller/PartController.java
@@ -2,6 +2,7 @@ package mediHub_be.part.controller;
 
 import lombok.RequiredArgsConstructor;
 import mediHub_be.part.dto.PartDTO;
+import mediHub_be.part.dto.PartRequestDTO;
 import mediHub_be.part.service.PartService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -21,15 +22,21 @@ public class PartController {
         return ResponseEntity.ok(parts);
     }
 
+    @GetMapping("/{deptSeq}")
+    public ResponseEntity<List<PartDTO>> getAllPartsByDept(@PathVariable Long deptSeq) {
+        List<PartDTO> parts = partService.getAllPartsByDept(deptSeq);
+        return ResponseEntity.ok(parts);
+    }
+
     @PostMapping
-    public ResponseEntity<PartDTO> createPart(@RequestBody PartDTO partDTO) {
-        PartDTO createdPart = partService.createPart(partDTO);
+    public ResponseEntity<PartDTO> createPart(@RequestBody PartRequestDTO partRequestDTO) {
+        PartDTO createdPart = partService.createPart(partRequestDTO);
         return ResponseEntity.ok(createdPart);
     }
 
     @PutMapping("/{partSeq}")
-    public ResponseEntity<PartDTO> updatePart(@PathVariable long partSeq, @RequestBody PartDTO partDTO) {
-        PartDTO updatedPart = partService.updatePart(partSeq, partDTO);
+    public ResponseEntity<PartDTO> updatePart(@RequestBody PartDTO partDTO) {
+        PartDTO updatedPart = partService.updatePart(partDTO);
         return ResponseEntity.ok(updatedPart);
     }
 

--- a/src/main/java/mediHub_be/part/dto/PartRequestDTO.java
+++ b/src/main/java/mediHub_be/part/dto/PartRequestDTO.java
@@ -1,0 +1,9 @@
+package mediHub_be.part.dto;
+
+import lombok.Data;
+
+@Data
+public class PartRequestDTO {
+    private long deptSeq;
+    private String partName;
+}

--- a/src/main/java/mediHub_be/part/entity/Part.java
+++ b/src/main/java/mediHub_be/part/entity/Part.java
@@ -5,6 +5,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import mediHub_be.common.aggregate.entity.BaseFullEntity;
 import mediHub_be.dept.entity.Dept;
 import org.hibernate.annotations.SQLDelete;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -14,8 +15,8 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Entity
 @Table(name = "part")
 @EntityListeners(AuditingEntityListener.class)
-@SQLDelete(sql = "UPDATE part SET del_date = LOCALTIME WHERE part_seq = ?")
-public class Part {
+@SQLDelete(sql = "UPDATE part SET deleted_at = LOCALTIME WHERE part_seq = ?")
+public class Part extends BaseFullEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/mediHub_be/part/repository/PartRepository.java
+++ b/src/main/java/mediHub_be/part/repository/PartRepository.java
@@ -3,5 +3,8 @@ package mediHub_be.part.repository;
 import mediHub_be.part.entity.Part;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface PartRepository extends JpaRepository<Part, Long> {
+    List<Part> findByDept_DeptSeqOrderByPartName(Long deptSeq);
 }

--- a/src/main/java/mediHub_be/part/service/PartService.java
+++ b/src/main/java/mediHub_be/part/service/PartService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import mediHub_be.dept.entity.Dept;
 import mediHub_be.dept.repository.DeptRepository;
 import mediHub_be.part.dto.PartDTO;
+import mediHub_be.part.dto.PartRequestDTO;
 import mediHub_be.part.entity.Part;
 import mediHub_be.part.repository.PartRepository;
 import org.springframework.stereotype.Service;
@@ -32,14 +33,14 @@ public class PartService {
     }
 
     @Transactional
-    public PartDTO createPart(PartDTO partDTO) {
+    public PartDTO createPart(PartRequestDTO partRequestDTO) {
 
-        Dept dept = deptRepository.findById(partDTO.getDeptSeq())
+        Dept dept = deptRepository.findById(partRequestDTO.getDeptSeq())
                 .orElseThrow(() -> new RuntimeException("Dept not found"));
 
         Part part = Part.builder()
                 .dept(dept)
-                .partName(partDTO.getPartName())
+                .partName(partRequestDTO.getPartName())
                 .build();
 
         part = partRepository.save(part);
@@ -52,8 +53,8 @@ public class PartService {
     }
 
     @Transactional
-    public PartDTO updatePart(long partSeq, PartDTO partDTO) {
-        Part part = partRepository.findById(partSeq)
+    public PartDTO updatePart(PartDTO partDTO) {
+        Part part = partRepository.findById(partDTO.getPartSeq())
                 .orElseThrow(() -> new RuntimeException("Part not found"));
 
         // Dept 객체 조회
@@ -76,5 +77,16 @@ public class PartService {
             throw new RuntimeException("Part not found");
         }
         partRepository.deleteById(partSeq);
+    }
+    @Transactional(readOnly = true)
+    public List<PartDTO> getAllPartsByDept(Long deptSeq) {
+        return partRepository.findByDept_DeptSeqOrderByPartName(deptSeq)
+                .stream()
+                .map(part -> PartDTO.builder()
+                        .partSeq(part.getPartSeq())
+                        .partName(part.getPartName())
+                        .build())
+                .collect(Collectors.toList());
+
     }
 }

--- a/src/main/java/mediHub_be/ranking/entity/Ranking.java
+++ b/src/main/java/mediHub_be/ranking/entity/Ranking.java
@@ -13,7 +13,6 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Entity
 @Table(name = "ranking")
 @EntityListeners(AuditingEntityListener.class)
-@SQLDelete(sql = "UPDATE rank SET del_date = LOCALTIME WHERE ranking_seq = ?")
 public class Ranking {
 
     @Id

--- a/src/main/java/mediHub_be/user/entity/User.java
+++ b/src/main/java/mediHub_be/user/entity/User.java
@@ -15,7 +15,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Table(name = "user")
 @Getter
 @EntityListeners(AuditingEntityListener.class)
-@SQLDelete(sql = "UPDATE user SET user_state = 'DELETE', del_date = LOCALTIME WHERE user_seq = ?")
+@SQLDelete(sql = "UPDATE user SET user_state = 'DELETE', deleted_at = LOCALTIME WHERE user_seq = ?")
 public class User extends BaseFullEntity {
 
     @Id


### PR DESCRIPTION
# 구현한 기능
## 사진 저장 방식 수정
### 기존 방식 
- 사진 파일 자체를 서버에서 전송받아 place홀더로 대체함. url은 s3에 보내고 해당 s3 url을 content에 저장
### 변경된 방식
- json형식으로 사진 파일을 base64로 인코딩해 서버에서 전송함. 해당 base64 형식 이미지 파일을 디코딩해 s3에 저장 후 url을 반환받음. 반환받은 url이 base64 파일을 대체하도록 함.

## 그 외 자잘한 수정
- part 조회 dto 수정
- 충돌 해결